### PR TITLE
Fix ios::binary detection on MinGW64

### DIFF
--- a/macros/sidtune.m4
+++ b/macros/sidtune.m4
@@ -55,7 +55,7 @@ AC_DEFUN([MY_CHECK_IOS_BIN],
     [
         AC_TRY_COMPILE(
             [#include <fstream>],
-            [std::ifstream myTest(0,std::ios::in|std::ios::binary);],
+            [std::ifstream myTest("",std::ios::in|std::ios::binary);],
             [test_cv_have_ios_binary=yes],
             [test_cv_have_ios_binary=no]
         )


### PR DESCRIPTION
call ifstream constructor with the proper parameter
```
configure:7730: checking whether standard member ios::binary is available
configure:7748: g++ -c -march=native -O2 -pipe -I/home/user/install/include conftest.cpp >&5
conftest.cpp: In function 'int main()':
conftest.cpp:53:53: error: call of overloaded 'basic_ifstream(int, std::_Ios_Openmode)' is ambiguous
   53 | std::ifstream myTest(0,std::ios::in|std::ios::binary);
      |                                                     ^
In file included from conftest.cpp:49:
C:/msys64/mingw64/include/c++/13.1.0/fstream:569:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream(const std::string&, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::string = std::__cxx11::basic_string<char>; std::ios_base::openmode = std::ios_base::openmode]'
  569 |       basic_ifstream(const std::string& __s,
      |       ^~~~~~~~~~~~~~
C:/msys64/mingw64/include/c++/13.1.0/fstream:551:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream(const wchar_t*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]'
  551 |       basic_ifstream(const wchar_t* __s,
      |       ^~~~~~~~~~~~~~
C:/msys64/mingw64/include/c++/13.1.0/fstream:536:7: note: candidate: 'std::basic_ifstream<_CharT, _Traits>::basic_ifstream(const char*, std::ios_base::openmode) [with _CharT = char; _Traits = std::char_traits<char>; std::ios_base::openmode = std::ios_base::openmode]'
  536 |       basic_ifstream(const char* __s, ios_base::openmode __mode = ios_base::in)
```