### PR TITLE
Fix function prototype

### DIFF
--- a/src/libpsid64/exomizer/radix.h
+++ b/src/libpsid64/exomizer/radix.h
@@ -50,7 +50,7 @@ void radix_tree_free(radix_root rr,     /* IN */
 
 void radix_tree_init(radix_root rr);    /* IN */
 
-void radix_node_set(radix_root rr,      /* IN */
+void radix_node_set(radix_rootp rrp,    /* IN */
                     unsigned int index, /* IN */
                     void *data);        /* IN */
 


### PR DESCRIPTION
to match with the function declaration
```
exomizer/radix.c:91:33: error: argument 1 of type 'radix_rootp' {aka 'struct _radix_root *'} declare
d as a pointer [-Werror=array-parameter=]
   91 | void radix_node_set(radix_rootp rrp,    /* IN */
      |                     ~~~~~~~~~~~~^~~
In file included from exomizer/radix.c:32:
exomizer/radix.h:53:32: note: previously declared as an array 'struct _radix_root[1]'
   53 | void radix_node_set(radix_root rr,      /* IN */
      |                     ~~~~~~~~~~~^~
cc1.exe: all warnings being treated as errors
```